### PR TITLE
Add option to choose default tab active behaviour (background/foreground)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,12 +8,17 @@ module.exports = {
 	env: {},
 
 	globals: {
-		'browser': true,
+		browser: true,
 	},
 
 	rules: {
-		'no-param-reassign'    : 'off',
-		'no-shadow'            : [ 'error', { 'allow': [ '_' ] } ],
-		'no-unused-expressions': [ 'warn', { allowShortCircuit: true, allowTernary: true } ],
+		'no-param-reassign': 'off',
+		'no-shadow': [ 'error', {
+			allow: [ '_' ],
+		}],
+		'no-unused-expressions': [ 'warn', {
+			allowShortCircuit: true,
+			allowTernary: true,
+		}],
 	},
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,6 +12,7 @@ module.exports = {
 	},
 
 	rules: {
+		'no-console': 'warn',
 		'no-param-reassign': 'off',
 		'no-shadow': [ 'error', {
 			allow: [ '_' ],

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
 
 ## Options
 
-- Hold down <kbd>shift</kbd> when selecting 'Open image in new tab' from the context menu to load the image in the background rather than the foreground.
+- Hold down <kbd>shift</kbd> when selecting "_Open image in new tab_" from the context menu to invert the default tab active behaviour.  
+  i.e. if "_Switch to image tab immediately_" is set to "_Yes_" then holding <kbd>shift</kbd> will load the image tab in the background rather than the foreground.
 
 
 ## Restrictions

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "ISC",
   "scripts": {
     "test": "npm run lint && npm run lint-ext",
-    "lint": "eslint \"**/*.js\"",
+    "lint": "eslint --max-warnings 0 \"**/*.js\"",
     "lint-ext": "web-ext lint --source-dir src",
     "start": "web-ext run --source-dir src --firefox=firefoxdeveloperedition --firefox-profile=dev-edition-default",
     "package": "web-ext build --source-dir src --ignore-files .DS_Store"

--- a/src/background.js
+++ b/src/background.js
@@ -13,7 +13,7 @@ const insertAfterActiveTab = async ( url, active, openerTabId ) => {
 
 		return browser.tabs.create({ url, active, openerTabId, index });
 	} catch ( err ) {
-		console.error( err );
+		console.error( err ); // eslint-disable-line no-console
 		// Do **not** provide the openerTabId as that may affect the tab position.
 		return browser.tabs.create({ url, active });
 	}
@@ -26,7 +26,7 @@ const insertAtEnd = async ( url, active, openerTabId ) => {
 		const index = tabs.length;
 		return browser.tabs.create({ url, active, openerTabId, index });
 	} catch ( err ) {
-		console.error( err );
+		console.error( err ); // eslint-disable-line no-console
 		// Do **not** provide the openerTabId as that may affect the tab position.
 		return browser.tabs.create({ url, active });
 	}

--- a/src/background.js
+++ b/src/background.js
@@ -1,6 +1,10 @@
 const isShiftKey = xs => xs.map( x => x.toLowerCase() ).includes( 'shift' );
 const isDataUri = uri => uri.startsWith( 'data:' );
 
+// :: Bool -> Bool -> Bool
+const isActive = ( switchToTabImmediatelyOption, modifierKeySelected ) => {
+	return (switchToTabImmediatelyOption && !modifierKeySelected) || (!switchToTabImmediatelyOption && modifierKeySelected);
+};
 
 const insertAfterActiveTab = async ( url, active, openerTabId ) => {
 	try {
@@ -42,9 +46,10 @@ const openImage = async ( info, tab ) => {
 		url = `/image.html#${info.srcUrl}`;
 	}
 
-	const active = !isShiftKey( info.modifiers );
+	const opts = await browser.storage.sync.get([ 'openAfterCurrentTab', 'switchToTabImmediately' ]);
+	const switchToTabImmediately = opts.switchToTabImmediately === 'YES';
+	const active = isActive( switchToTabImmediately, isShiftKey( info.modifiers ) );
 
-	const opts = await browser.storage.sync.get( 'openAfterCurrentTab' );
 	if ( opts.openAfterCurrentTab ) {
 		return insertAfterActiveTab( url, active, tab.id );
 	}

--- a/src/options.html
+++ b/src/options.html
@@ -7,16 +7,38 @@
 	<link rel="stylesheet" href="styles/options.css">
 </head>
 <body>
-	<form class="form">
+	<form id="options-form" class="form">
 		<div class="form-field form-field--checkbox">
 			<div class="form-input-checkbox-wrap">
 				<label class="form-label" for="openAfterCurrentTab">Open image after current tab</label>
-				<input class="form-input" type="checkbox" id="openAfterCurrentTab" data-option>
+				<input class="form-input" type="checkbox" name="openAfterCurrentTab" id="openAfterCurrentTab" data-option>
 			</div>
 
-			<span class="form-hint">
+			<div class="form-hint">
 				If checked, the image will be opened after the current active tab, otherwise it will be opened at the end of the tab list.
-			</span>
+			</div>
+		</div>
+
+		<div class="form-field">
+			<div class="form-label">Switch to image tab immediately</div>
+
+			<div class="form-input-radio-options">
+				<div class="form-input-radio-option">
+					<input class="form-input" type="radio" name="switchToTabImmediately" id="switchToTabImmediately_YES" value="YES" data-option>
+					<label for="switchToTabImmediately_YES">Yes</label>
+				</div>
+
+				<div class="form-input-radio-option">
+					<input class="form-input" type="radio" name="switchToTabImmediately" id="switchToTabImmediately_NO" value="NO" data-option checked>
+					<label for="switchToTabImmediately_NO">No</label>
+				</div>
+			</div>
+
+			<div class="form-hint">
+				When opening the image in a new tab, should the browser switch to that tab immediately or load it in the background?
+				<br>
+				You can invert this default behaviour by holding down the <kbd>shift</kbd> key when selecting "Open image in new tab" from the context menu.
+			</div>
 		</div>
 
 		<footer class="form-actions">

--- a/src/scripts/options.js
+++ b/src/scripts/options.js
@@ -5,15 +5,25 @@ const optionFields = _ => {
 const saveOptions = e => {
 	e.preventDefault();
 
-	const options = optionFields().reduce(( acc, option ) => {
-		const inputType = option.getAttribute( 'type' );
-		let value = option.value;
+	const options = optionFields().reduce(( acc, input ) => {
+		const optionId = input.getAttribute( 'name' );
+		const inputType = input.getAttribute( 'type' );
 
-		if ( inputType === 'checkbox' ) {
-			value = option.checked;
+		switch ( inputType ) {
+			case 'checkbox':
+				acc[optionId] = input.checked;
+				break;
+
+			case 'radio':
+				if ( input.checked ) {
+					acc[optionId] = input.value;
+				}
+				break;
+
+			default:
+				acc[optionId] = input.value;
 		}
 
-		acc[option.id] = value;
 		return acc;
 	}, {} );
 
@@ -22,17 +32,26 @@ const saveOptions = e => {
 
 
 const restoreOptions = async _ => {
-	const optionIds = optionFields().map( option => option.id );
+	const optionIds = optionFields().map( input => input.getAttribute( 'name' ) );
 	const storedOptions = await browser.storage.sync.get( optionIds );
 
-	optionFields().forEach(option => {
-		const optionName = option.id;
-		const inputType = option.getAttribute( 'type' );
+	optionFields().forEach(input => {
+		const optionId = input.getAttribute( 'name' );
+		const inputType = input.getAttribute( 'type' );
 
-		if ( inputType === 'checkbox' ) {
-			option.checked = storedOptions[optionName];
-		} else {
-			option.value = storedOptions[optionName];
+		switch ( inputType ) {
+			case 'checkbox':
+				input.checked = storedOptions[optionId];
+				break;
+
+			case 'radio':
+				if ( input.value === storedOptions[optionId] ) {
+					input.checked = true;
+				}
+				break;
+
+			default:
+				input.value = storedOptions[optionId];
 		}
 	});
 };

--- a/src/styles/options.css
+++ b/src/styles/options.css
@@ -3,7 +3,7 @@
 }
 
 .form-field {
-	margin-bottom: 10px;
+	margin-bottom: 16px;
 }
 
 .form-input-checkbox-wrap {
@@ -12,11 +12,12 @@
 
 .form-label {
 	display: block;
+	font-weight: bold;
 }
 
 .form-hint {
 	display: block;
-	font-style: italic;
+	margin-top: 4px;
 }
 
 .form-input--text-like {

--- a/src/styles/options.css
+++ b/src/styles/options.css
@@ -1,3 +1,19 @@
+/* Generic */
+kbd {
+	display: inline-block;
+	vertical-align: middle;
+	padding: 2px 5px;
+	background-color: #fafbfc;
+	border: 1px solid #d1d5da;
+	border-bottom-color: #d1d5da;
+	border-radius: 6px;
+	box-shadow: inset 0 -1px 0 #d1d5da;
+	font-family: monospace;
+	line-height: 10px;
+	color: #444d56;
+}
+
+/* Form */
 .form {
 	padding: 10px 0;
 }


### PR DESCRIPTION
Partial fix for #7.

This gives the user the option to choose the default tab active behaviour but it will not use the global "_When you open a new tab, switch to it immediately_" setting from `about:preferences`.